### PR TITLE
Adding sorcerer & wizard to tasha's caustic brew

### DIFF
--- a/spell-classes.json
+++ b/spell-classes.json
@@ -438,7 +438,7 @@
   	"swordburst": "artificer,sorcerer,warlock,wizard",
 	"synapticstatic": "bard,sorcerer,warlock,wizard",
     "symbol": "bard,cleric,wizard",
-    "tashascausticbrew": "artificer",
+    "tashascausticbrew": "artificer,sorcerer,wizard",
     "tashashideouslaughter": "bard,wizard",
     "hideouslaughter": "bard,wizard",
     "tashasmindwhip": "sorcerer,wizard",


### PR DESCRIPTION
I noticed Tasha's Caustic Brew was missing sorcerer & wizard classes.