### PR TITLE
Fixes for issue #41 and #43

### DIFF
--- a/Patchnotes.md
+++ b/Patchnotes.md
@@ -1,3 +1,6 @@
+#0.8.2
+- Fixed Class searching for spells - issue: #43
+- Fixed Drag-and-Drop error in Foundry V10  - issue: #41
 #0.8
 - Merged PR [League-of-Foundry-Developers/compendium-browser#40](https://github.com/League-of-Foundry-Developers/compendium-browser/pull/40): Foundry v10 support
 #0.7

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Tired of scrolling compendia? Easily browse and filter for spells, feats, items,
 Compendium Browser is faster and better-behaved; **it no longer loads all the compendia into memory on start-up** (which sometimes hung servers because of memory or CPU requirements). Instead, it filters and loads on-demand, as well as giving you a Module Setting to control how many rows are loaded at a time.
 
 [Patch Notes](https://raw.githubusercontent.com/League-of-Foundry-Developers/compendium-browser/master/Patchnotes.md)
+## v0.8:
+- Compatibility with Foundry V10
+- Added check for "Compendium Folders" module 'phantom' actors (#[CF_tempEntity]) to filter out of NPC list.
+- Fix to handle un-migrated compendiums (they get auto-excluded from the browser even if selected)
 ## v0.7:
 - Supports Foundry 0.8.x and Foundry 9
 - Faster searches using Foundry 0.8.x queries (thanks ZoltantheDM!)

--- a/compendium-browser.js
+++ b/compendium-browser.js
@@ -187,11 +187,18 @@ class CompendiumBrowser extends Application {
                     event.preventDefault();
                     return false;
                 }
-                event.dataTransfer.setData("text/plain", JSON.stringify({
-                    type: pack.documentName,
-                    pack: pack.collection,
-                    id: li.getAttribute("data-entry-id")
-                }));
+                if (CompendiumBrowser.isFoundryV10Plus) {
+                    event.dataTransfer.setData("text/plain", JSON.stringify({
+                        type: pack.documentName,
+                        uuid: `Compendium.${pack.collection}.${li.getAttribute("data-entry-id")}`
+                      }));
+                } else {
+                    event.dataTransfer.setData("text/plain", JSON.stringify({
+                        type: pack.documentName,
+                        pack: pack.collection,
+                        id: li.getAttribute("data-entry-id")
+                    }));
+                }
             }, false);
         });
     }
@@ -1408,7 +1415,8 @@ class CompendiumBrowser extends Application {
             );
             this.addSpellFilter(game.i18n.localize("CMPBrowser.general"), game.i18n.localize("CMPBrowser.spellType"), 'system.actionType', 'select', CONFIG.DND5E.itemActionTypes);
             this.addSpellFilter(game.i18n.localize("CMPBrowser.general"), game.i18n.localize("CMPBrowser.damageType"), 'damageTypes', 'select', CONFIG.DND5E.damageTypes);
-            this.addSpellFilter(game.i18n.localize("CMPBrowser.general"), game.i18n.localize("CMPBrowser.class"), 'system.classes', 'select',
+            //JV-082: Fix for missing "Class" search feature
+            this.addSpellFilter(game.i18n.localize("CMPBrowser.general"), game.i18n.localize("CMPBrowser.class"), 'classes', 'select',
                 {
                     artificer: game.i18n.localize("CMPBrowser.artificer"),
                     bard: game.i18n.localize("CMPBrowser.bard"),

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "compendium-browser",
     "title": "Compendium Browser",
     "description": "<p>Easily browse and filter spells, feats, items, and npcs loaded from compendia!</p><p>Verified with Foundry 9 and 10 only</p><strong>Compendium Browser is faster and better-behaved;</strong> it no longer loads all the compendia into memory on start-up (which sometimes hung servers because of memory or CPU requirements). Instead, it filters and loads on-demand, as well as giving you a Module Setting to control how many rows are loaded at a time.<br>Changes in 0.7.0: Supports Foundry 0.8+ only; faster searches using Foundry 0.8 queries!",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "author": "Spetzel#0103",
       "authors": [
         {
@@ -59,7 +59,7 @@
     ],
     "url": "https://github.com/League-of-Foundry-Developers/compendium-browser",
     "manifest": "https://github.com/League-of-Foundry-Developers/compendium-browser/releases/latest/download/module.json",
-    "download": "https://github.com/League-of-Foundry-Developers/compendium-browser/releases/download/v0.8.1/compendium-browser.zip",
+    "download": "https://github.com/League-of-Foundry-Developers/compendium-browser/releases/download/v0.8.2/compendium-browser.zip",
     "minimumCoreVersion": "0.9.266",
     "compatibleCoreVersion": "10",
     "allowBugReporter": true,


### PR DESCRIPTION
Fixes for issues #43 (can't filter spells by class) and #41 (drag and drop not working in Foundry V10)  